### PR TITLE
always add total_samples found in streaminfo

### DIFF
--- a/lib/Audio/Scan.pm
+++ b/lib/Audio/Scan.pm
@@ -598,6 +598,7 @@ The following metadata about a file is returned:
     maximum_framesize
     audio_md5
     total_samples
+    total_samples_streaminfo
 
 =head2 TAGS
 

--- a/src/flac.c
+++ b/src/flac.c
@@ -704,6 +704,7 @@ _flac_parse_streaminfo(flacinfo *flac)
   my_hv_store( flac->info, "channels", newSVuv(flac->channels) );
   my_hv_store( flac->info, "bits_per_sample", newSVuv(flac->bits_per_sample) );
   my_hv_store( flac->info, "total_samples", newSVnv(flac->total_samples) );
+  my_hv_store( flac->info, "total_samples_streaminfo", newSVnv(flac->total_samples) );
 
   bptr = buffer_ptr(flac->buf);
   md5 = newSVpvf("%02x", bptr[0]);


### PR DESCRIPTION
A flac header (which is optional, as it is a streamable format) contains a "total_sample" entry which can be used to calculate duration. When unknown (which is legitimate), that entry must be set to 0

Audio::Scan, when that entry is 0, seeks to the end of the file to read samples counts but the problem is that if only a part of the file has been given (e.g. just read the header of an online file in a tmp resource), then samples count estimation is wrong and the caller has no idea if the total_sample can be used or not.

The idea is to add a field that always contains the untouched total_samples value from the streaminfo header